### PR TITLE
fix(imports): use ASV2State instead of ASVState

### DIFF
--- a/all_seaing_controller/all_seaing_controller/simple_controller.py
+++ b/all_seaing_controller/all_seaing_controller/simple_controller.py
@@ -2,7 +2,7 @@
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Float64
-from all_seaing_interfaces.msg import ASVState
+from all_seaing_interfaces.msg import ASV2State
 
 
 class SimpleController(Node):
@@ -27,7 +27,7 @@ class SimpleController(Node):
             Float64, "thrusters/right/thrust", 10
         )
         self.command_sub = self.create_subscription(
-            ASVState, "asv_state", self.command_callback, 10
+            ASV2State, "asv_state", self.command_callback, 10
         )
 
     def command_callback(self, msg):


### PR DESCRIPTION
ASVState no longer exists (probably due to ROS2 update?). I have no idea what this is or what it does, but changing this will get all_seaing_controller to build again, so it's probably a good idea?