### PR TITLE
Bayesian grid map cell probability update

### DIFF
--- a/all_seaing_bringup/launch/perception.launch.py
+++ b/all_seaing_bringup/launch/perception.launch.py
@@ -504,6 +504,10 @@ def launch_setup(context, *args, **kwargs):
             {"inv_decay_rate": 1.2},
             {"default_lidar_range": 40.0},
             {"dynamic_origin": True},
+            {"bayesian": True},
+            {"prob_occ_occ": 0.95},
+            {"prob_occ_non_occ": 0.35},
+            {"prior_occ": 0.45},
         ],
     )
 

--- a/all_seaing_bringup/launch/sim.launch.py
+++ b/all_seaing_bringup/launch/sim.launch.py
@@ -527,6 +527,10 @@ def launch_setup(context, *args, **kwargs):
             {"inflate_dist": 2.5},
             {"inv_decay_rate": 1.2},
             {"default_lidar_range": 40.0},
+            {"bayesian": True},
+            {"prob_occ_occ": 0.95},
+            {"prob_occ_non_occ": 0.35},
+            {"prior_occ": 0.45},
         ],
         remappings=[
             ("scan", "/wamv/sensors/lidars/lidar_wamv_sensor/scan"),

--- a/all_seaing_navigation/all_seaing_navigation/grid_map_generator.py
+++ b/all_seaing_navigation/all_seaing_navigation/grid_map_generator.py
@@ -83,6 +83,12 @@ class GridMapGenerator(Node):
             .bool_value
         )
 
+        self.bayesian = (
+            self.declare_parameter("bayesian", False)
+            .get_parameter_value()
+            .bool_value
+        )
+
         # --------------- SUBSCRIBERS, PUBLISHERS, AND TIMERS ---------------#
 
         self.obstacle_map_sub = self.create_subscription(
@@ -125,7 +131,8 @@ class GridMapGenerator(Node):
 
         self.grid.data = [-1] * self.grid.info.width * self.grid.info.height
         self.active_cells = [False] * self.grid.info.width * self.grid.info.height
-        self.log_odds = [self.prior_occ] * self.grid.info.width * self.grid.info.height
+        if self.bayesian:
+            self.log_odds = [self.prior_occ] * self.grid.info.width * self.grid.info.height
 
     def world_to_grid(self, x, y):
         """Convert world coordinates to grid coordinates."""
@@ -272,7 +279,8 @@ class GridMapGenerator(Node):
                 for x in range(x_start, x_end + 1):
                     if 0 <= x < self.grid.info.width and 0 <= y < self.grid.info.height:
                         self.active_cells[x + y * self.grid.info.width] = make_active
-                        # self.grid.data[x + y * self.grid.info.width] = 100
+                        if not self.bayesian:
+                            self.grid.data[x + y * self.grid.info.width] = 100
 
             for edge in active_edge_table:
                 edge["x"] += edge["inverse_slope"]
@@ -307,24 +315,32 @@ class GridMapGenerator(Node):
                     y - self.ship_pos[1]
                 ) ** 2 > lidar_range_grid**2:
                     continue
-                # curVal = self.grid.data[x + y * self.grid.info.width]
-                # if curVal == -1:
-                #     curVal = self.prior_occ*100.0
-                prev_log_odds = self.log_odds[x + y * self.grid.info.width]
-                if self.active_cells[x + y * self.grid.info.width]:
-                    # curVal += 1
-                    # curVal *= 5
-                    # curVal = min(100, curVal)
-                    # curVal = 100.0*self.from_log_odds(self.to_log_odds(curVal/100.0)-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_occ))
-                    new_log_odds = prev_log_odds-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_occ)
+                if not self.bayesian:
+                    curVal = self.grid.data[x + y * self.grid.info.width]
+                    if curVal == -1:
+                        # curVal = self.prior_occ*100.0
+                        curVal = 0
                 else:
-                    # curVal /= self.decay_rate # decrease probability by some small amount
-                    # curVal = 100.0*self.from_log_odds(self.to_log_odds(curVal/100.0)-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_non_occ))
-                    new_log_odds = prev_log_odds-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_non_occ)
-                # curVal = math.floor(curVal)
-                new_log_odds = min(max(new_log_odds, -5.0), 20.0) # to allow for rapid update in case of global map drift
-                curVal = math.floor(self.from_log_odds(new_log_odds)*100.0)
-                self.log_odds[x + y * self.grid.info.width] = new_log_odds
+                    prev_log_odds = self.log_odds[x + y * self.grid.info.width]
+                if self.active_cells[x + y * self.grid.info.width]:
+                    if not self.bayesian:
+                        curVal += 1
+                        curVal *= 5
+                        curVal = min(100, curVal)
+                    else:
+                        # curVal = 100.0*self.from_log_odds(self.to_log_odds(curVal/100.0)-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_occ))
+                        new_log_odds = prev_log_odds-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_occ)
+                else:
+                    if not self.bayesian:
+                        curVal /= self.decay_rate # decrease probability by some small amount
+                        curVal = math.floor(curVal)
+                    else:
+                        # curVal = 100.0*self.from_log_odds(self.to_log_odds(curVal/100.0)-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_non_occ))
+                        new_log_odds = prev_log_odds-self.to_log_odds(self.prior_occ)+self.to_log_odds(self.prob_occ_non_occ)
+                if self.bayesian:
+                    new_log_odds = min(max(new_log_odds, -5.0), 20.0) # to allow for rapid update in case of global map drift
+                    curVal = math.floor(self.from_log_odds(new_log_odds)*100.0)
+                    self.log_odds[x + y * self.grid.info.width] = new_log_odds
                 self.grid.data[x + y * self.grid.info.width] = curVal
 
     def timer_callback(self):


### PR DESCRIPTION
Honestly, after fine-tuning & clipping the log-odds, it has really similar behavior to the previous probability update (maybe less susceptible to noise bc it takes longer to go from -5 log-odds to occupied? and also decays occupancy at a lower rate, but that can also be tuned in the initial grid map, it's just that this one is essentially changing exponentially instead of linearly, but the previous one was also increasing kind of exponentially), and idk if it's worth the change/which one is better to use. It probably makes more sense from a theoretical perspective, and the parameters are more intuitive (probability of occupancy given measurement, and prior on occupancy), and if we remove the clipping, it will be more persistent & less susceptible to noise, but if the global map drifts it will essentially never adapt to the new positions without the clipping (but does ok with the clipping, similar to the previous one).